### PR TITLE
Update NetworkFormatter.js

### DIFF
--- a/detox/src/client/actions/formatters/sync-resources/NetworkFormatter.js
+++ b/detox/src/client/actions/formatters/sync-resources/NetworkFormatter.js
@@ -1,7 +1,7 @@
 const { makeResourceTitle, makeResourceSubTitle } = require('./utils');
 
 function makeURLDescription(url, urlCount) {
-  return makeResourceSubTitle(`URL #${urlCount}: ${url}.`);
+  return makeResourceSubTitle(`URL #${urlCount}: ${url}`);
 }
 
 module.exports = function(properties) {


### PR DESCRIPTION
In logs network address we have this: 
```
• 1 network requests with URLs:
  - URL #1: https://google.com/api.
```

And this `.` at the end is very confusing when try to click on this link.
Suggest to remove this `.`